### PR TITLE
refactor: centralize A2A method names in A2AMethods interface

### DIFF
--- a/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
+++ b/client/transport/grpc/src/main/java/io/a2a/client/transport/grpc/GrpcTransport.java
@@ -1,5 +1,15 @@
 package io.a2a.client.transport.grpc;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 import static io.a2a.util.Assert.checkNotNullParam;
 
 import java.util.List;
@@ -18,17 +28,7 @@ import io.a2a.grpc.A2AServiceGrpc.A2AServiceBlockingV2Stub;
 import io.a2a.grpc.A2AServiceGrpc.A2AServiceStub;
 import io.a2a.grpc.utils.ProtoUtils.FromProto;
 import io.a2a.grpc.utils.ProtoUtils.ToProto;
-import io.a2a.jsonrpc.common.wrappers.CancelTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTasksRequest;
 import io.a2a.jsonrpc.common.wrappers.ListTasksResult;
-import io.a2a.jsonrpc.common.wrappers.SendMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SendStreamingMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import io.a2a.spec.A2AClientException;
 import io.a2a.spec.AgentCard;
 import io.a2a.spec.DeleteTaskPushNotificationConfigParams;
@@ -95,7 +95,7 @@ public class GrpcTransport implements ClientTransport {
         MessageSendParams tenantRequest = createRequestWithTenant(request);
 
         io.a2a.grpc.SendMessageRequest sendMessageRequest = createGrpcSendMessageRequest(tenantRequest, context);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SendMessageRequest.METHOD, sendMessageRequest,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SEND_MESSAGE_METHOD, sendMessageRequest,
                 agentCard, context);
 
         try {
@@ -121,7 +121,7 @@ public class GrpcTransport implements ClientTransport {
         MessageSendParams tenantRequest = createRequestWithTenant(request);
 
         io.a2a.grpc.SendMessageRequest grpcRequest = createGrpcSendMessageRequest(tenantRequest, context);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SendStreamingMessageRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SEND_STREAMING_MESSAGE_METHOD,
                 grpcRequest, agentCard, context);
         StreamObserver<io.a2a.grpc.StreamResponse> streamObserver = new EventStreamObserver(eventConsumer, errorConsumer);
 
@@ -143,7 +143,7 @@ public class GrpcTransport implements ClientTransport {
         }
         requestBuilder.setTenant(resolveTenant(request.tenant()));
         io.a2a.grpc.GetTaskRequest getTaskRequest = requestBuilder.build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskRequest.METHOD, getTaskRequest,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_METHOD, getTaskRequest,
                 agentCard, context);
 
         try {
@@ -162,8 +162,7 @@ public class GrpcTransport implements ClientTransport {
                 .setName("tasks/" + request.id())
                 .setTenant(resolveTenant(request.tenant()))
                 .build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(CancelTaskRequest.METHOD, cancelTaskRequest,
-                agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(CANCEL_TASK_METHOD, cancelTaskRequest, agentCard, context);
 
         try {
             A2AServiceBlockingV2Stub stubWithMetadata = createBlockingStubWithMetadata(context, payloadAndHeaders);
@@ -201,8 +200,7 @@ public class GrpcTransport implements ClientTransport {
         }
         requestBuilder.setTenant(resolveTenant(request.tenant()));
         io.a2a.grpc.ListTasksRequest listTasksRequest = requestBuilder.build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(ListTasksRequest.METHOD, listTasksRequest,
-                agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(LIST_TASK_METHOD, listTasksRequest, agentCard, context);
 
         try {
             A2AServiceBlockingV2Stub stubWithMetadata = createBlockingStubWithMetadata(context, payloadAndHeaders);
@@ -233,8 +231,7 @@ public class GrpcTransport implements ClientTransport {
                 .setConfigId(configId != null ? configId : request.taskId())
                 .setTenant(resolveTenant(request.tenant()))
                 .build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SetTaskPushNotificationConfigRequest.METHOD,
-                grpcRequest, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, grpcRequest, agentCard, context);
 
         try {
             A2AServiceBlockingV2Stub stubWithMetadata = createBlockingStubWithMetadata(context, payloadAndHeaders);
@@ -254,8 +251,7 @@ public class GrpcTransport implements ClientTransport {
                 .setName(getTaskPushNotificationConfigName(request))
                 .setTenant(resolveTenant(request.tenant()))
                 .build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskPushNotificationConfigRequest.METHOD,
-                grpcRequest, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, grpcRequest, agentCard, context);
 
         try {
             A2AServiceBlockingV2Stub stubWithMetadata = createBlockingStubWithMetadata(context, payloadAndHeaders);
@@ -277,7 +273,7 @@ public class GrpcTransport implements ClientTransport {
                 .setPageSize(request.pageSize())
                 .setPageToken(request.pageToken())
                 .build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(ListTaskPushNotificationConfigRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD,
                 grpcRequest, agentCard, context);
 
         try {
@@ -298,8 +294,7 @@ public class GrpcTransport implements ClientTransport {
                 .setName(getTaskPushNotificationConfigName(request.id(), request.pushNotificationConfigId()))
                 .setTenant(resolveTenant(request.tenant()))
                 .build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(DeleteTaskPushNotificationConfigRequest.METHOD,
-                grpcRequest, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, grpcRequest, agentCard, context);
 
         try {
             A2AServiceBlockingV2Stub stubWithMetadata = createBlockingStubWithMetadata(context, payloadAndHeaders);
@@ -319,8 +314,7 @@ public class GrpcTransport implements ClientTransport {
                 .setTenant(resolveTenant(request.tenant()))
                 .setName("tasks/" + request.id())
                 .build();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SubscribeToTaskRequest.METHOD,
-                grpcRequest, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SUBSCRIBE_TO_TASK_METHOD, grpcRequest, agentCard, context);
 
         StreamObserver<io.a2a.grpc.StreamResponse> streamObserver = new EventStreamObserver(eventConsumer, errorConsumer);
 

--- a/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransport.java
+++ b/client/transport/jsonrpc/src/main/java/io/a2a/client/transport/jsonrpc/JSONRPCTransport.java
@@ -1,5 +1,16 @@
 package io.a2a.client.transport.jsonrpc;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_EXTENDED_AGENT_CARD_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 import static io.a2a.util.Assert.checkNotNullParam;
 
 import java.io.IOException;
@@ -24,27 +35,17 @@ import io.a2a.grpc.utils.ProtoUtils;
 import io.a2a.jsonrpc.common.json.JsonProcessingException;
 import io.a2a.jsonrpc.common.wrappers.A2AMessage;
 import io.a2a.jsonrpc.common.wrappers.A2AResponse;
-import io.a2a.jsonrpc.common.wrappers.CancelTaskRequest;
 import io.a2a.jsonrpc.common.wrappers.CancelTaskResponse;
-import io.a2a.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
 import io.a2a.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigResponse;
 import io.a2a.jsonrpc.common.wrappers.GetAuthenticatedExtendedCardRequest;
 import io.a2a.jsonrpc.common.wrappers.GetAuthenticatedExtendedCardResponse;
-import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
 import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigResponse;
-import io.a2a.jsonrpc.common.wrappers.GetTaskRequest;
 import io.a2a.jsonrpc.common.wrappers.GetTaskResponse;
-import io.a2a.jsonrpc.common.wrappers.ListTaskPushNotificationConfigRequest;
 import io.a2a.jsonrpc.common.wrappers.ListTaskPushNotificationConfigResponse;
-import io.a2a.jsonrpc.common.wrappers.ListTasksRequest;
 import io.a2a.jsonrpc.common.wrappers.ListTasksResponse;
 import io.a2a.jsonrpc.common.wrappers.ListTasksResult;
-import io.a2a.jsonrpc.common.wrappers.SendMessageRequest;
 import io.a2a.jsonrpc.common.wrappers.SendMessageResponse;
-import io.a2a.jsonrpc.common.wrappers.SendStreamingMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SetTaskPushNotificationConfigRequest;
 import io.a2a.jsonrpc.common.wrappers.SetTaskPushNotificationConfigResponse;
-import io.a2a.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.A2AClientException;
 import io.a2a.spec.A2AError;
@@ -93,12 +94,12 @@ public class JSONRPCTransport implements ClientTransport {
     @Override
     public EventKind sendMessage(MessageSendParams request, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SendMessageRequest.METHOD, ProtoUtils.ToProto.sendMessageRequest(request),
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SEND_MESSAGE_METHOD, ProtoUtils.ToProto.sendMessageRequest(request),
                 agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SendMessageRequest.METHOD);
-            SendMessageResponse response = unmarshalResponse(httpResponseBody, SendMessageRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SEND_MESSAGE_METHOD);
+            SendMessageResponse response = unmarshalResponse(httpResponseBody, SEND_MESSAGE_METHOD);
             return response.getResult();
         } catch (A2AClientException e) {
             throw e;
@@ -112,14 +113,14 @@ public class JSONRPCTransport implements ClientTransport {
                                      @Nullable Consumer<Throwable> errorConsumer, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
         checkNotNullParam("eventConsumer", eventConsumer);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SendStreamingMessageRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SEND_STREAMING_MESSAGE_METHOD,
                 ProtoUtils.ToProto.sendMessageRequest(request), agentCard, context);
 
         final AtomicReference<CompletableFuture<Void>> ref = new AtomicReference<>();
         SSEEventListener sseEventListener = new SSEEventListener(eventConsumer, errorConsumer);
 
         try {
-            A2AHttpClient.PostBuilder builder = createPostBuilder(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SendStreamingMessageRequest.METHOD);
+            A2AHttpClient.PostBuilder builder = createPostBuilder(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SEND_STREAMING_MESSAGE_METHOD);
             ref.set(builder.postAsyncSSE(
                     msg -> sseEventListener.onMessage(msg, ref.get()),
                     throwable -> sseEventListener.onError(throwable, ref.get()),
@@ -139,12 +140,12 @@ public class JSONRPCTransport implements ClientTransport {
     @Override
     public Task getTask(TaskQueryParams request, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskRequest.METHOD, ProtoUtils.ToProto.getTaskRequest(request),
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_METHOD, ProtoUtils.ToProto.getTaskRequest(request),
                 agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, GetTaskRequest.METHOD);
-            GetTaskResponse response = unmarshalResponse(httpResponseBody, GetTaskRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, GET_TASK_METHOD);
+            GetTaskResponse response = unmarshalResponse(httpResponseBody, GET_TASK_METHOD);
             return response.getResult();
         } catch (A2AClientException e) {
             throw e;
@@ -156,12 +157,12 @@ public class JSONRPCTransport implements ClientTransport {
     @Override
     public Task cancelTask(TaskIdParams request, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(CancelTaskRequest.METHOD, ProtoUtils.ToProto.cancelTaskRequest(request),
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(CANCEL_TASK_METHOD, ProtoUtils.ToProto.cancelTaskRequest(request),
                 agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, CancelTaskRequest.METHOD);
-            CancelTaskResponse response = unmarshalResponse(httpResponseBody, CancelTaskRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, CANCEL_TASK_METHOD);
+            CancelTaskResponse response = unmarshalResponse(httpResponseBody, CANCEL_TASK_METHOD);
             return response.getResult();
         } catch (A2AClientException e) {
             throw e;
@@ -173,11 +174,11 @@ public class JSONRPCTransport implements ClientTransport {
     @Override
     public ListTasksResult listTasks(ListTasksParams request, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(ListTasksRequest.METHOD, ProtoUtils.ToProto.listTasksParams(request),
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(LIST_TASK_METHOD, ProtoUtils.ToProto.listTasksParams(request),
                 agentCard, context);
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, ListTasksRequest.METHOD);
-            ListTasksResponse response = unmarshalResponse(httpResponseBody, ListTasksRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, LIST_TASK_METHOD);
+            ListTasksResponse response = unmarshalResponse(httpResponseBody, LIST_TASK_METHOD);
             return response.getResult();
         } catch (IOException | InterruptedException | JsonProcessingException e) {
             throw new A2AClientException("Failed to list tasks: " + e, e);
@@ -188,13 +189,12 @@ public class JSONRPCTransport implements ClientTransport {
     public TaskPushNotificationConfig setTaskPushNotificationConfiguration(TaskPushNotificationConfig request,
                                                                            @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SetTaskPushNotificationConfigRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD,
                 ProtoUtils.ToProto.setTaskPushNotificationConfigRequest(request), agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SetTaskPushNotificationConfigRequest.METHOD);
-            SetTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody,
-                    SetTaskPushNotificationConfigRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
+            SetTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
             return response.getResult();
         } catch (A2AClientException e) {
             throw e;
@@ -207,13 +207,12 @@ public class JSONRPCTransport implements ClientTransport {
     public TaskPushNotificationConfig getTaskPushNotificationConfiguration(GetTaskPushNotificationConfigParams request,
                                                                            @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskPushNotificationConfigRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD,
                 ProtoUtils.ToProto.getTaskPushNotificationConfigRequest(request), agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders,GetTaskPushNotificationConfigRequest.METHOD);
-            GetTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody,
-                    GetTaskPushNotificationConfigRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
+            GetTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody, GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
             return response.getResult();
         } catch (A2AClientException e) {
             throw e;
@@ -227,13 +226,12 @@ public class JSONRPCTransport implements ClientTransport {
             ListTaskPushNotificationConfigParams request,
             @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(ListTaskPushNotificationConfigRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD,
                 ProtoUtils.ToProto.listTaskPushNotificationConfigRequest(request), agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, ListTaskPushNotificationConfigRequest.METHOD);
-            ListTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody,
-                    ListTaskPushNotificationConfigRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
+            ListTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody, LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
             return response.getResult();
         } catch (A2AClientException e) {
             throw e;
@@ -246,12 +244,12 @@ public class JSONRPCTransport implements ClientTransport {
     public void deleteTaskPushNotificationConfigurations(DeleteTaskPushNotificationConfigParams request,
                                                          @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(DeleteTaskPushNotificationConfigRequest.METHOD,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD,
                 ProtoUtils.ToProto.deleteTaskPushNotificationConfigRequest(request), agentCard, context);
 
         try {
-            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders,DeleteTaskPushNotificationConfigRequest.METHOD);
-            DeleteTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody, DeleteTaskPushNotificationConfigRequest.METHOD);
+            String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
+            DeleteTaskPushNotificationConfigResponse response = unmarshalResponse(httpResponseBody, DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
             // Response validated (no error), but no result to return
         } catch (A2AClientException e) {
             throw e;
@@ -266,14 +264,13 @@ public class JSONRPCTransport implements ClientTransport {
         checkNotNullParam("request", request);
         checkNotNullParam("eventConsumer", eventConsumer);
         checkNotNullParam("errorConsumer", errorConsumer);
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SubscribeToTaskRequest.METHOD,
-                ProtoUtils.ToProto.subscribeToTaskRequest(request), agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SUBSCRIBE_TO_TASK_METHOD, ProtoUtils.ToProto.subscribeToTaskRequest(request), agentCard, context);
 
         AtomicReference<CompletableFuture<Void>> ref = new AtomicReference<>();
         SSEEventListener sseEventListener = new SSEEventListener(eventConsumer, errorConsumer);
 
         try {
-            A2AHttpClient.PostBuilder builder = createPostBuilder(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders,SubscribeToTaskRequest.METHOD);
+            A2AHttpClient.PostBuilder builder = createPostBuilder(Utils.buildBaseUrl(agentInterface, request.tenant()), payloadAndHeaders, SUBSCRIBE_TO_TASK_METHOD);
             ref.set(builder.postAsyncSSE(
                     msg -> sseEventListener.onMessage(msg, ref.get()),
                     throwable -> sseEventListener.onError(throwable, ref.get()),
@@ -307,13 +304,12 @@ public class JSONRPCTransport implements ClientTransport {
                     .jsonrpc(A2AMessage.JSONRPC_VERSION)
                     .build(); // id will be randomly generated
 
-            PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetAuthenticatedExtendedCardRequest.METHOD,
-                    ProtoUtils.ToProto.extendedAgentCard(getExtendedAgentCardRequest), agentCard, context);
+            PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_EXTENDED_AGENT_CARD_METHOD,
+                    ProtoUtils.ToProto.extendedAgentCard(), agentCard, context);
 
             try {
-                String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, ""), payloadAndHeaders,GetAuthenticatedExtendedCardRequest.METHOD);
-                GetAuthenticatedExtendedCardResponse response = unmarshalResponse(httpResponseBody,
-                        GetAuthenticatedExtendedCardRequest.METHOD);
+                String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, ""), payloadAndHeaders, GET_EXTENDED_AGENT_CARD_METHOD);
+                GetAuthenticatedExtendedCardResponse response = unmarshalResponse(httpResponseBody, GET_EXTENDED_AGENT_CARD_METHOD);
                 agentCard = response.getResult();
                 needsExtendedCard = false;
                 return agentCard;

--- a/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
+++ b/client/transport/rest/src/main/java/io/a2a/client/transport/rest/RestTransport.java
@@ -1,5 +1,15 @@
 package io.a2a.client.transport.rest;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 import static io.a2a.util.Assert.checkNotNullParam;
 
 import java.io.IOException;
@@ -28,17 +38,7 @@ import io.a2a.client.transport.spi.interceptors.PayloadAndHeaders;
 import io.a2a.grpc.utils.ProtoUtils;
 import io.a2a.jsonrpc.common.json.JsonProcessingException;
 import io.a2a.jsonrpc.common.json.JsonUtil;
-import io.a2a.jsonrpc.common.wrappers.CancelTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTasksRequest;
 import io.a2a.jsonrpc.common.wrappers.ListTasksResult;
-import io.a2a.jsonrpc.common.wrappers.SendMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SendStreamingMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import io.a2a.spec.A2AClientError;
 import io.a2a.spec.A2AClientException;
 import io.a2a.spec.AgentCard;
@@ -83,7 +83,7 @@ public class RestTransport implements ClientTransport {
     public EventKind sendMessage(MessageSendParams messageSendParams, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("messageSendParams", messageSendParams);
         io.a2a.grpc.SendMessageRequest.Builder builder = io.a2a.grpc.SendMessageRequest.newBuilder(ProtoUtils.ToProto.sendMessageRequest(messageSendParams));
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SendMessageRequest.METHOD, builder, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SEND_MESSAGE_METHOD, builder, agentCard, context);
         try {
             String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, messageSendParams.tenant()) + "/message:send", payloadAndHeaders);
             io.a2a.grpc.SendMessageResponse.Builder responseBuilder = io.a2a.grpc.SendMessageResponse.newBuilder();
@@ -108,8 +108,7 @@ public class RestTransport implements ClientTransport {
         checkNotNullParam("eventConsumer", eventConsumer);
         checkNotNullParam("messageSendParams", messageSendParams);
         io.a2a.grpc.SendMessageRequest.Builder builder = io.a2a.grpc.SendMessageRequest.newBuilder(ProtoUtils.ToProto.sendMessageRequest(messageSendParams));
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SendStreamingMessageRequest.METHOD,
-                builder, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SEND_STREAMING_MESSAGE_METHOD, builder, agentCard, context);
         AtomicReference<CompletableFuture<Void>> ref = new AtomicReference<>();
         RestSSEEventListener sseEventListener = new RestSSEEventListener(eventConsumer, errorConsumer);
         try {
@@ -134,8 +133,7 @@ public class RestTransport implements ClientTransport {
         checkNotNullParam("taskQueryParams", taskQueryParams);
         io.a2a.grpc.GetTaskRequest.Builder builder = io.a2a.grpc.GetTaskRequest.newBuilder();
         builder.setName("tasks/" + taskQueryParams.id());
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskRequest.METHOD, builder,
-                agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_METHOD, builder, agentCard, context);
         try {
             StringBuilder url = new StringBuilder(Utils.buildBaseUrl(agentInterface, taskQueryParams.tenant()));
             if (taskQueryParams.historyLength() != null && taskQueryParams.historyLength() > 0) {
@@ -169,8 +167,7 @@ public class RestTransport implements ClientTransport {
         checkNotNullParam("taskIdParams", taskIdParams);
         io.a2a.grpc.CancelTaskRequest.Builder builder = io.a2a.grpc.CancelTaskRequest.newBuilder();
         builder.setName("tasks/" + taskIdParams.id());
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(CancelTaskRequest.METHOD, builder,
-                agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(CANCEL_TASK_METHOD, builder, agentCard, context);
         try {
             String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, taskIdParams.tenant()) + String.format("/tasks/%1s:cancel", taskIdParams.id()), payloadAndHeaders);
             io.a2a.grpc.Task.Builder responseBuilder = io.a2a.grpc.Task.newBuilder();
@@ -209,8 +206,7 @@ public class RestTransport implements ClientTransport {
             builder.setIncludeArtifacts(true);
         }
 
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(ListTasksRequest.METHOD, builder,
-                agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(LIST_TASK_METHOD, builder, agentCard, context);
 
         try {
             // Build query string
@@ -282,7 +278,7 @@ public class RestTransport implements ClientTransport {
         if (request.pushNotificationConfig().id() != null) {
             builder.setConfigId(request.pushNotificationConfig().id());
         }
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SetTaskPushNotificationConfigRequest.METHOD, builder, agentCard, context);
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, builder, agentCard, context);
         try {
             String httpResponseBody = sendPostRequest(Utils.buildBaseUrl(agentInterface, request.tenant()) + String.format("/tasks/%1s/pushNotificationConfigs", request.taskId()), payloadAndHeaders);
             io.a2a.grpc.TaskPushNotificationConfig.Builder responseBuilder = io.a2a.grpc.TaskPushNotificationConfig.newBuilder();
@@ -310,7 +306,7 @@ public class RestTransport implements ClientTransport {
             builder.setName(String.format("/tasks/%1s/pushNotificationConfigs/", request.id()));
             url.append(builder.getName());
         }
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskPushNotificationConfigRequest.METHOD, builder,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, builder,
                 agentCard, context);
         try {
             A2AHttpClient.GetBuilder getBuilder = httpClient.createGet().url(url.toString());
@@ -340,7 +336,7 @@ public class RestTransport implements ClientTransport {
         io.a2a.grpc.ListTaskPushNotificationConfigRequest.Builder builder
                 = io.a2a.grpc.ListTaskPushNotificationConfigRequest.newBuilder();
         builder.setParent(String.format("/tasks/%1s/pushNotificationConfigs", request.id()));
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(ListTaskPushNotificationConfigRequest.METHOD, builder,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, builder,
                 agentCard, context);
         try {
             String url = Utils.buildBaseUrl(agentInterface, request.tenant()) + String.format("/tasks/%1s/pushNotificationConfigs", request.id());
@@ -369,7 +365,7 @@ public class RestTransport implements ClientTransport {
     public void deleteTaskPushNotificationConfigurations(DeleteTaskPushNotificationConfigParams request, @Nullable ClientCallContext context) throws A2AClientException {
         checkNotNullParam("request", request);
         io.a2a.grpc.DeleteTaskPushNotificationConfigRequestOrBuilder builder = io.a2a.grpc.DeleteTaskPushNotificationConfigRequest.newBuilder();
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(DeleteTaskPushNotificationConfigRequest.METHOD, builder,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, builder,
                 agentCard, context);
         try {
             String url = Utils.buildBaseUrl(agentInterface, request.tenant()) + String.format("/tasks/%1s/pushNotificationConfigs/%2s", request.id(), request.pushNotificationConfigId());
@@ -396,7 +392,7 @@ public class RestTransport implements ClientTransport {
         checkNotNullParam("request", request);
         io.a2a.grpc.SubscribeToTaskRequest.Builder builder = io.a2a.grpc.SubscribeToTaskRequest.newBuilder();
         builder.setName("tasks/" + request.id());
-        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SubscribeToTaskRequest.METHOD, builder,
+        PayloadAndHeaders payloadAndHeaders = applyInterceptors(SUBSCRIBE_TO_TASK_METHOD, builder,
                 agentCard, context);
         AtomicReference<CompletableFuture<Void>> ref = new AtomicReference<>();
         RestSSEEventListener sseEventListener = new RestSSEEventListener(eventConsumer, errorConsumer);
@@ -430,8 +426,7 @@ public class RestTransport implements ClientTransport {
             if (!needsExtendedCard) {
                 return agentCard;
             }
-            PayloadAndHeaders payloadAndHeaders = applyInterceptors(GetTaskRequest.METHOD, null,
-                    agentCard, context);
+            PayloadAndHeaders payloadAndHeaders = applyInterceptors(GET_TASK_METHOD, null, agentCard, context);
             String url = Utils.buildBaseUrl(agentInterface, "") + "/extendedAgentCard";
             A2AHttpClient.GetBuilder getBuilder = httpClient.createGet().url(url);
             if (payloadAndHeaders.getHeaders() != null) {

--- a/jsonrpc-common/pom.xml
+++ b/jsonrpc-common/pom.xml
@@ -13,14 +13,13 @@
 
     <packaging>jar</packaging>
 
-    <name>Java SDK A2A Internal</name>
+    <name>Java SDK A2A JSONRPC Common</name>
     <description>Java SDK for the Agent2Agent Protocol (A2A) - Internal implementation utilities (not part of public API)</description>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-spec</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/CancelTaskRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/CancelTaskRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.TaskIdParams;
@@ -25,9 +27,6 @@ import io.a2a.spec.TaskState;
  */
 public final class CancelTaskRequest extends NonStreamingJSONRPCRequest<TaskIdParams> {
 
-    /** The JSON-RPC method name for canceling tasks. */
-    public static final String METHOD = "CancelTask";
-
     /**
      * Creates a new CancelTaskRequest with the specified JSON-RPC parameters.
      *
@@ -37,7 +36,7 @@ public final class CancelTaskRequest extends NonStreamingJSONRPCRequest<TaskIdPa
      * @throws IllegalArgumentException if jsonrpc version is invalid, method is not "CancelTask", params is null, or id is not a String/Integer/null
      */
     public CancelTaskRequest(String jsonrpc, Object id, TaskIdParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, CANCEL_TASK_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/DeleteTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/DeleteTaskPushNotificationConfigRequest.java
@@ -1,8 +1,11 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+
 import java.util.UUID;
 
 import io.a2a.spec.DeleteTaskPushNotificationConfigParams;
+
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
 
 /**
  * JSON-RPC request to delete a push notification configuration from a task.
@@ -19,9 +22,6 @@ import io.a2a.spec.DeleteTaskPushNotificationConfigParams;
  */
 public final class DeleteTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<DeleteTaskPushNotificationConfigParams> {
 
-    /** The JSON-RPC method name for deleting push notification configurations. */
-    public static final String METHOD = "DeleteTaskPushNotificationConfig";
-
     /**
      * Creates a new DeleteTaskPushNotificationConfigRequest with the specified JSON-RPC parameters.
      *
@@ -31,7 +31,7 @@ public final class DeleteTaskPushNotificationConfigRequest extends NonStreamingJ
      * @throws IllegalArgumentException if jsonrpc version is invalid, method is not "DeleteTaskPushNotificationConfig", or id is not a string/integer/null
      */
     public DeleteTaskPushNotificationConfigRequest(String jsonrpc, Object id, DeleteTaskPushNotificationConfigParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/GetAuthenticatedExtendedCardRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/GetAuthenticatedExtendedCardRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.GET_EXTENDED_AGENT_CARD_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.AgentCard;
@@ -31,9 +33,6 @@ import io.a2a.spec.AuthenticatedExtendedCardNotConfiguredError;
  */
 public final class GetAuthenticatedExtendedCardRequest extends NonStreamingJSONRPCRequest<Void> {
 
-    /** The JSON-RPC method name for getting extended agent card. */
-    public static final String METHOD = "GetExtendedAgentCard";
-
     /**
      * Constructs request with full parameters.
      *
@@ -41,7 +40,7 @@ public final class GetAuthenticatedExtendedCardRequest extends NonStreamingJSONR
      * @param id the request ID
      */
     public GetAuthenticatedExtendedCardRequest(String jsonrpc, Object id) {
-        super(jsonrpc, METHOD, id);
+        super(jsonrpc, GET_EXTENDED_AGENT_CARD_METHOD, id);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/GetTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/GetTaskPushNotificationConfigRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.GetTaskPushNotificationConfigParams;
@@ -20,9 +22,6 @@ import io.a2a.spec.TaskPushNotificationConfig;
  */
 public final class GetTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<GetTaskPushNotificationConfigParams> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "GetTaskPushNotificationConfig";
-
     /**
      * Constructs request with all parameters.
      *
@@ -31,7 +30,7 @@ public final class GetTaskPushNotificationConfigRequest extends NonStreamingJSON
      * @param params the request parameters
      */
     public GetTaskPushNotificationConfigRequest(String jsonrpc, Object id, GetTaskPushNotificationConfigParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/GetTaskRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/GetTaskRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.Task;
@@ -21,9 +23,6 @@ import io.a2a.spec.TaskQueryParams;
  */
 public final class GetTaskRequest extends NonStreamingJSONRPCRequest<TaskQueryParams> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "GetTask";
-
     /**
      * Constructs request with all parameters.
      *
@@ -32,7 +31,7 @@ public final class GetTaskRequest extends NonStreamingJSONRPCRequest<TaskQueryPa
      * @param params the request parameters
      */
     public GetTaskRequest(String jsonrpc, Object id, TaskQueryParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, GET_TASK_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/ListTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/ListTaskPushNotificationConfigRequest.java
@@ -1,9 +1,12 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+
 import java.util.UUID;
 
 import io.a2a.spec.ListTaskPushNotificationConfigParams;
 import io.a2a.spec.TaskPushNotificationConfig;
+
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
 
 /**
  * JSON-RPC request to list all push notification configurations for a task.
@@ -20,9 +23,6 @@ import io.a2a.spec.TaskPushNotificationConfig;
  */
 public final class ListTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<ListTaskPushNotificationConfigParams> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "ListTaskPushNotificationConfig";
-
     /**
      * Constructs request with all parameters.
      *
@@ -31,7 +31,7 @@ public final class ListTaskPushNotificationConfigRequest extends NonStreamingJSO
      * @param params the request parameters
      */
     public ListTaskPushNotificationConfigRequest(String jsonrpc, Object id, ListTaskPushNotificationConfigParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/ListTasksRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/ListTasksRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.LIST_TASK_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.ListTasksParams;
@@ -9,9 +11,6 @@ import io.a2a.spec.ListTasksParams;
  */
 public final class ListTasksRequest extends NonStreamingJSONRPCRequest<ListTasksParams> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "ListTasks";
-
     /**
      * Constructs request with all parameters.
      *
@@ -20,7 +19,7 @@ public final class ListTasksRequest extends NonStreamingJSONRPCRequest<ListTasks
      * @param params the request parameters
      */
     public ListTasksRequest(String jsonrpc, Object id, ListTasksParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, LIST_TASK_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SendMessageRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SendMessageRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.MessageSendParams;
@@ -23,7 +25,7 @@ import io.a2a.spec.Task;
  * with the {@code SendStreamingMessage} method instead.
  * <p>
  * This class includes a fluent {@link Builder} for convenient request construction. The method
- * name is fixed as {@value #METHOD} and is set automatically by the constructor.
+ * name is fixed as "SendMessage" and is set automatically by the constructor.
  *
  * @see SendStreamingMessageRequest
  * @see MessageSendParams
@@ -31,11 +33,6 @@ import io.a2a.spec.Task;
  * @see <a href="https://a2a-protocol.org/latest/">A2A Protocol Specification</a>
  */
 public final class SendMessageRequest extends NonStreamingJSONRPCRequest<MessageSendParams> {
-
-    /**
-     * The JSON-RPC method name for sending a message: "SendMessage".
-     */
-    public static final String METHOD = "SendMessage";
 
     /**
      * Constructs a SendMessageRequest with the specified JSON-RPC fields.
@@ -49,7 +46,7 @@ public final class SendMessageRequest extends NonStreamingJSONRPCRequest<Message
      * @throws IllegalArgumentException if validation fails
      */
     public SendMessageRequest(String jsonrpc, Object id, MessageSendParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, SEND_MESSAGE_METHOD, id, params);
     }
 
     /**
@@ -74,7 +71,7 @@ public final class SendMessageRequest extends NonStreamingJSONRPCRequest<Message
     /**
      * Builder for constructing {@link SendMessageRequest} instances with a fluent API.
      * <p>
-     * The method name is automatically set to {@value SendMessageRequest#METHOD} and cannot be changed.
+     * The method name is automatically set to "SendMessage" and cannot be changed.
      * If no ID is provided, a UUID will be auto-generated when {@link #build()} is called.
      * <p>
      * Example usage:

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SendStreamingMessageRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SendStreamingMessageRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.MessageSendParams;
@@ -24,9 +26,6 @@ import io.a2a.spec.StreamingEventKind;
  */
 public final class SendStreamingMessageRequest extends StreamingJSONRPCRequest<MessageSendParams> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "SendStreamingMessage";
-
     /**
      * Constructs request with all parameters.
      *
@@ -35,7 +34,7 @@ public final class SendStreamingMessageRequest extends StreamingJSONRPCRequest<M
      * @param params the request parameters
      */
     public SendStreamingMessageRequest(String jsonrpc, Object id, MessageSendParams params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, SEND_STREAMING_MESSAGE_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SetTaskPushNotificationConfigRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SetTaskPushNotificationConfigRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.PushNotificationConfig;
@@ -21,9 +23,6 @@ import io.a2a.spec.TaskPushNotificationConfig;
  */
 public final class SetTaskPushNotificationConfigRequest extends NonStreamingJSONRPCRequest<TaskPushNotificationConfig> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "SetTaskPushNotificationConfig";
-
     /**
      * Constructs request with all parameters.
      *
@@ -32,7 +31,7 @@ public final class SetTaskPushNotificationConfigRequest extends NonStreamingJSON
      * @param params the request parameters
      */
     public SetTaskPushNotificationConfigRequest(String jsonrpc, Object id, TaskPushNotificationConfig params) {
-        super(jsonrpc, METHOD, id, params);
+        super(jsonrpc, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, id, params);
     }
 
     /**

--- a/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SubscribeToTaskRequest.java
+++ b/jsonrpc-common/src/main/java/io/a2a/jsonrpc/common/wrappers/SubscribeToTaskRequest.java
@@ -1,5 +1,7 @@
 package io.a2a.jsonrpc.common.wrappers;
 
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
+
 import java.util.UUID;
 
 import io.a2a.spec.StreamingEventKind;
@@ -27,9 +29,6 @@ import io.a2a.spec.TaskIdParams;
  */
 public final class SubscribeToTaskRequest extends StreamingJSONRPCRequest<TaskIdParams> {
 
-    /** The JSON-RPC method name. */
-    public static final String METHOD = "SubscribeToTask";
-
     /**
      * Constructs request with all parameters.
      *
@@ -38,7 +37,7 @@ public final class SubscribeToTaskRequest extends StreamingJSONRPCRequest<TaskId
      * @param params the request parameters
      */
     public SubscribeToTaskRequest(String jsonrpc, Object id, TaskIdParams params) {
-        super(jsonrpc, METHOD, id == null ? UUID.randomUUID().toString() : id, params);
+        super(jsonrpc, SUBSCRIBE_TO_TASK_METHOD, id == null ? UUID.randomUUID().toString() : id, params);
     }
 
     /**

--- a/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
+++ b/reference/jsonrpc/src/test/java/io/a2a/server/apps/quarkus/A2AServerRoutesTest.java
@@ -1,5 +1,8 @@
 package io.a2a.server.apps.quarkus;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_EXTENDED_AGENT_CARD_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
 import static io.a2a.spec.AgentCard.CURRENT_PROTOCOL_VERSION;
 import static io.a2a.transport.jsonrpc.context.JSONRPCContextKeys.METHOD_NAME_KEY;
 import static java.util.Collections.singletonList;
@@ -56,6 +59,14 @@ import io.vertx.ext.web.RoutingContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 
 /**
  * Unit test for JSON-RPC A2AServerRoutes that verifies the method names are properly set
@@ -154,7 +165,7 @@ public class A2AServerRoutesTest {
         verify(mockJsonRpcHandler).onMessageSend(any(SendMessageRequest.class), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SendMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SEND_MESSAGE_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -201,7 +212,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SendStreamingMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SEND_STREAMING_MESSAGE_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -238,7 +249,7 @@ public class A2AServerRoutesTest {
         verify(mockJsonRpcHandler).onGetTask(any(GetTaskRequest.class), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(GET_TASK_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -274,7 +285,7 @@ public class A2AServerRoutesTest {
         verify(mockJsonRpcHandler).onCancelTask(any(CancelTaskRequest.class), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(CancelTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(CANCEL_TASK_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -306,7 +317,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SubscribeToTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SUBSCRIBE_TO_TASK_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -357,7 +368,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -397,7 +408,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(GetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -437,7 +448,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(ListTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -469,13 +480,13 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(DeleteTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
     public void testGetAuthenticatedExtendedCard_MethodNameSetInContext() {
         // Arrange
-        String jsonRpcRequest = "{\"jsonrpc\":\"2.0\",\"id\":\"5\",\"method\":\"" + GetAuthenticatedExtendedCardRequest.METHOD
+        String jsonRpcRequest = "{\"jsonrpc\":\"2.0\",\"id\":\"5\",\"method\":\"" + GET_EXTENDED_AGENT_CARD_METHOD
                 + "\",\"id\":1}";
         when(mockRequestBody.asString()).thenReturn(jsonRpcRequest);
 
@@ -506,7 +517,7 @@ public class A2AServerRoutesTest {
                 any(GetAuthenticatedExtendedCardRequest.class), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(GetAuthenticatedExtendedCardRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(GET_EXTENDED_AGENT_CARD_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     /**

--- a/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
+++ b/reference/rest/src/main/java/io/a2a/server/rest/quarkus/A2AServerRoutes.java
@@ -1,5 +1,7 @@
 package io.a2a.server.rest.quarkus;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
 import static io.a2a.transport.rest.context.RestContextKeys.HEADERS_KEY;
 import static io.a2a.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
@@ -21,16 +23,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import io.a2a.common.A2AHeaders;
-import io.a2a.jsonrpc.common.wrappers.CancelTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTasksRequest;
-import io.a2a.jsonrpc.common.wrappers.SendMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SendStreamingMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import io.a2a.server.ServerCallContext;
 import io.a2a.server.auth.UnauthenticatedUser;
 import io.a2a.server.auth.User;
@@ -57,6 +49,15 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import org.jspecify.annotations.Nullable;
 
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
+
 @Singleton
 @Authenticated
 public class A2AServerRoutes {
@@ -82,7 +83,7 @@ public class A2AServerRoutes {
 
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)message:send$", order = 1, methods = {Route.HttpMethod.POST}, consumes = {APPLICATION_JSON}, type = Route.HandlerType.BLOCKING)
     public void sendMessage(@Body String body, RoutingContext rc) {
-        ServerCallContext context = createCallContext(rc, SendMessageRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, SEND_MESSAGE_METHOD);
         HTTPRestResponse response = null;
         try {
             response = jsonRestHandler.sendMessage(body, extractTenant(rc), context);
@@ -95,7 +96,7 @@ public class A2AServerRoutes {
 
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)message:stream$", order = 1, methods = {Route.HttpMethod.POST}, consumes = {APPLICATION_JSON}, type = Route.HandlerType.BLOCKING)
     public void sendMessageStreaming(@Body String body, RoutingContext rc) {
-        ServerCallContext context = createCallContext(rc, SendStreamingMessageRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, SEND_STREAMING_MESSAGE_METHOD);
         HTTPRestStreamingResponse streamingResponse = null;
         HTTPRestResponse error = null;
         try {
@@ -120,7 +121,7 @@ public class A2AServerRoutes {
 
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\??", order = 0, methods = {Route.HttpMethod.GET}, type = Route.HandlerType.BLOCKING)
     public void listTasks(RoutingContext rc) {
-        ServerCallContext context = createCallContext(rc, ListTasksRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, LIST_TASK_METHOD);
         HTTPRestResponse response = null;
         try {
             // Extract query parameters
@@ -167,7 +168,7 @@ public class A2AServerRoutes {
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^:^/]+)$", order = 1, methods = {Route.HttpMethod.GET}, type = Route.HandlerType.BLOCKING)
     public void getTask(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
-        ServerCallContext context = createCallContext(rc, GetTaskRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, GET_TASK_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {
@@ -191,7 +192,7 @@ public class A2AServerRoutes {
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+):cancel$", order = 1, methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
     public void cancelTask(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
-        ServerCallContext context = createCallContext(rc, CancelTaskRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, CANCEL_TASK_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {
@@ -224,7 +225,7 @@ public class A2AServerRoutes {
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+):subscribe$", order = 1, methods = {Route.HttpMethod.POST}, type = Route.HandlerType.BLOCKING)
     public void subscribeToTask(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
-        ServerCallContext context = createCallContext(rc, SubscribeToTaskRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, SUBSCRIBE_TO_TASK_METHOD);
         HTTPRestStreamingResponse streamingResponse = null;
         HTTPRestResponse error = null;
         try {
@@ -254,7 +255,7 @@ public class A2AServerRoutes {
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs$", order = 1, methods = {Route.HttpMethod.POST}, consumes = {APPLICATION_JSON}, type = Route.HandlerType.BLOCKING)
     public void setTaskPushNotificationConfiguration(@Body String body, RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
-        ServerCallContext context = createCallContext(rc, SetTaskPushNotificationConfigRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {
@@ -273,7 +274,7 @@ public class A2AServerRoutes {
     public void getTaskPushNotificationConfiguration(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
         String configId = rc.pathParam("configId");
-        ServerCallContext context = createCallContext(rc, GetTaskPushNotificationConfigRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {
@@ -291,7 +292,7 @@ public class A2AServerRoutes {
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs\\/$", order = 1, methods = {Route.HttpMethod.GET}, type = Route.HandlerType.BLOCKING)
     public void getTaskPushNotificationConfigurationWithoutId(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
-        ServerCallContext context = createCallContext(rc, GetTaskPushNotificationConfigRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {
@@ -310,7 +311,7 @@ public class A2AServerRoutes {
     @Route(regex = "^\\/(?<tenant>[^\\/]*\\/?)tasks\\/(?<taskId>[^/]+)\\/pushNotificationConfigs", order = 3, methods = {Route.HttpMethod.GET}, type = Route.HandlerType.BLOCKING)
     public void listTaskPushNotificationConfigurations(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
-        ServerCallContext context = createCallContext(rc, ListTaskPushNotificationConfigRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {
@@ -339,7 +340,7 @@ public class A2AServerRoutes {
     public void deleteTaskPushNotificationConfiguration(RoutingContext rc) {
         String taskId = rc.pathParam("taskId");
         String configId = rc.pathParam("configId");
-        ServerCallContext context = createCallContext(rc, DeleteTaskPushNotificationConfigRequest.METHOD);
+        ServerCallContext context = createCallContext(rc, DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
         HTTPRestResponse response = null;
         try {
             if (taskId == null || taskId.isEmpty()) {

--- a/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
+++ b/reference/rest/src/test/java/io/a2a/server/rest/quarkus/A2AServerRoutesTest.java
@@ -1,5 +1,14 @@
 package io.a2a.server.rest.quarkus;
 
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 import static io.a2a.transport.rest.context.RestContextKeys.METHOD_NAME_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,15 +24,6 @@ import java.util.concurrent.Executor;
 
 import jakarta.enterprise.inject.Instance;
 
-import io.a2a.jsonrpc.common.wrappers.CancelTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.GetTaskRequest;
-import io.a2a.jsonrpc.common.wrappers.ListTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.SendMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SendStreamingMessageRequest;
-import io.a2a.jsonrpc.common.wrappers.SetTaskPushNotificationConfigRequest;
-import io.a2a.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import io.a2a.server.ServerCallContext;
 import io.a2a.transport.rest.handler.RestHandler;
 import io.a2a.transport.rest.handler.RestHandler.HTTPRestResponse;
@@ -105,7 +105,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).sendMessage(eq("{}"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SendMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SEND_MESSAGE_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -127,7 +127,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).sendStreamingMessage(eq("{}"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SendStreamingMessageRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SEND_STREAMING_MESSAGE_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -149,7 +149,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).getTask(eq("task123"), any(), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(GetTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(GET_TASK_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).cancelTask(eq("task123"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(CancelTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(CANCEL_TASK_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -194,7 +194,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).subscribeToTask(eq("task123"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SubscribeToTaskRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SUBSCRIBE_TO_TASK_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -217,7 +217,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).setTaskPushNotificationConfiguration(eq("task123"), eq("{}"), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(SetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -242,7 +242,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(GetTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -265,7 +265,7 @@ public class A2AServerRoutesTest {
         verify(mockRestHandler).listTaskPushNotificationConfigurations(eq("task123"), anyInt(), anyString(), anyString(), contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(ListTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     @Test
@@ -290,7 +290,7 @@ public class A2AServerRoutesTest {
                 contextCaptor.capture());
         ServerCallContext capturedContext = contextCaptor.getValue();
         assertNotNull(capturedContext);
-        assertEquals(DeleteTaskPushNotificationConfigRequest.METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
+        assertEquals(DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD, capturedContext.getState().get(METHOD_NAME_KEY));
     }
 
     /**

--- a/spec-grpc/pom.xml
+++ b/spec-grpc/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>a2a-java-sdk-jsonrpc-common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -97,7 +96,7 @@
             <plugin>
                 <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>4.0.2</version>
+                <version>4.0.3</version>
                 <configuration>
                     <skip>${skip.protobuf.generate}</skip>
                     <cleanOutputDirectories>true</cleanOutputDirectories>

--- a/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/utils/JSONRPCUtils.java
@@ -11,6 +11,9 @@ import static io.a2a.spec.A2AErrorCodes.PUSH_NOTIFICATION_NOT_SUPPORTED_ERROR_CO
 import static io.a2a.spec.A2AErrorCodes.TASK_NOT_CANCELABLE_ERROR_CODE;
 import static io.a2a.spec.A2AErrorCodes.TASK_NOT_FOUND_ERROR_CODE;
 import static io.a2a.spec.A2AErrorCodes.UNSUPPORTED_OPERATION_ERROR_CODE;
+import static io.a2a.spec.A2AMethods.CANCEL_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_EXTENDED_AGENT_CARD_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -71,6 +74,15 @@ import io.a2a.spec.TaskNotFoundError;
 import io.a2a.spec.UnsupportedOperationError;
 import io.a2a.util.Utils;
 import org.jspecify.annotations.Nullable;
+
+import static io.a2a.spec.A2AMethods.DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_METHOD;
+import static io.a2a.spec.A2AMethods.LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SEND_MESSAGE_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SUBSCRIBE_TO_TASK_METHOD;
 
 /**
  * Utilities for converting between JSON-RPC 2.0 messages and Protocol Buffer objects.
@@ -186,55 +198,55 @@ public class JSONRPCUtils {
 
     private static A2ARequest<?> parseMethodRequest(String version, Object id, String method, JsonElement paramsNode) throws InvalidParamsError, MethodNotFoundJsonMappingException, JsonProcessingException {
         switch (method) {
-            case GetTaskRequest.METHOD -> {
+            case GET_TASK_METHOD -> {
                 io.a2a.grpc.GetTaskRequest.Builder builder = io.a2a.grpc.GetTaskRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new GetTaskRequest(version, id, ProtoUtils.FromProto.taskQueryParams(builder));
             }
-            case CancelTaskRequest.METHOD -> {
+            case CANCEL_TASK_METHOD -> {
                 io.a2a.grpc.CancelTaskRequest.Builder builder = io.a2a.grpc.CancelTaskRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new CancelTaskRequest(version, id, ProtoUtils.FromProto.taskIdParams(builder));
             }
-            case ListTasksRequest.METHOD -> {
+            case LIST_TASK_METHOD -> {
                 io.a2a.grpc.ListTasksRequest.Builder builder = io.a2a.grpc.ListTasksRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new ListTasksRequest(version, id, ProtoUtils.FromProto.listTasksParams(builder));
             }
-            case SetTaskPushNotificationConfigRequest.METHOD -> {
+            case SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.SetTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.SetTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new SetTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.setTaskPushNotificationConfig(builder));
             }
-            case GetTaskPushNotificationConfigRequest.METHOD -> {
+            case GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.GetTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.GetTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new GetTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.getTaskPushNotificationConfigParams(builder));
             }
-            case SendMessageRequest.METHOD -> {
+            case SEND_MESSAGE_METHOD -> {
                 io.a2a.grpc.SendMessageRequest.Builder builder = io.a2a.grpc.SendMessageRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new SendMessageRequest(version, id, ProtoUtils.FromProto.messageSendParams(builder));
             }
-            case ListTaskPushNotificationConfigRequest.METHOD -> {
+            case LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.ListTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.ListTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new ListTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.listTaskPushNotificationConfigParams(builder));
             }
-            case DeleteTaskPushNotificationConfigRequest.METHOD -> {
+            case DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.DeleteTaskPushNotificationConfigRequest.Builder builder = io.a2a.grpc.DeleteTaskPushNotificationConfigRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new DeleteTaskPushNotificationConfigRequest(version, id, ProtoUtils.FromProto.deleteTaskPushNotificationConfigParams(builder));
             }
-            case GetAuthenticatedExtendedCardRequest.METHOD -> {
+            case GET_EXTENDED_AGENT_CARD_METHOD -> {
                 return new GetAuthenticatedExtendedCardRequest(version, id);
             }
-            case SendStreamingMessageRequest.METHOD -> {
+            case SEND_STREAMING_MESSAGE_METHOD -> {
                 io.a2a.grpc.SendMessageRequest.Builder builder = io.a2a.grpc.SendMessageRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new SendStreamingMessageRequest(version, id, ProtoUtils.FromProto.messageSendParams(builder));
             }
-            case SubscribeToTaskRequest.METHOD -> {
+            case SUBSCRIBE_TO_TASK_METHOD -> {
                 io.a2a.grpc.SubscribeToTaskRequest.Builder builder = io.a2a.grpc.SubscribeToTaskRequest.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new SubscribeToTaskRequest(version, id, ProtoUtils.FromProto.taskIdParams(builder));
@@ -268,32 +280,32 @@ public class JSONRPCUtils {
             return parseError(jsonRpc.getAsJsonObject("error"), id, method);
         }
         switch (method) {
-            case GetTaskRequest.METHOD -> {
+            case GET_TASK_METHOD -> {
                 io.a2a.grpc.Task.Builder builder = io.a2a.grpc.Task.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new GetTaskResponse(id, ProtoUtils.FromProto.task(builder));
             }
-            case CancelTaskRequest.METHOD -> {
+            case CANCEL_TASK_METHOD -> {
                 io.a2a.grpc.Task.Builder builder = io.a2a.grpc.Task.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new CancelTaskResponse(id, ProtoUtils.FromProto.task(builder));
             }
-            case ListTasksRequest.METHOD -> {
+            case LIST_TASK_METHOD -> {
                 io.a2a.grpc.ListTasksResponse.Builder builder = io.a2a.grpc.ListTasksResponse.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new ListTasksResponse(id, ProtoUtils.FromProto.listTasksResult(builder));
             }
-            case SetTaskPushNotificationConfigRequest.METHOD -> {
+            case SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.TaskPushNotificationConfig.Builder builder = io.a2a.grpc.TaskPushNotificationConfig.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new SetTaskPushNotificationConfigResponse(id, ProtoUtils.FromProto.taskPushNotificationConfig(builder));
             }
-            case GetTaskPushNotificationConfigRequest.METHOD -> {
+            case GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.TaskPushNotificationConfig.Builder builder = io.a2a.grpc.TaskPushNotificationConfig.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new GetTaskPushNotificationConfigResponse(id, ProtoUtils.FromProto.taskPushNotificationConfig(builder));
             }
-            case SendMessageRequest.METHOD -> {
+            case SEND_MESSAGE_METHOD -> {
                 io.a2a.grpc.SendMessageResponse.Builder builder = io.a2a.grpc.SendMessageResponse.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 if (builder.hasMsg()) {
@@ -301,15 +313,15 @@ public class JSONRPCUtils {
                 }
                 return new SendMessageResponse(id, ProtoUtils.FromProto.task(builder.getTask()));
             }
-            case ListTaskPushNotificationConfigRequest.METHOD -> {
+            case LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 io.a2a.grpc.ListTaskPushNotificationConfigResponse.Builder builder = io.a2a.grpc.ListTaskPushNotificationConfigResponse.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new ListTaskPushNotificationConfigResponse(id, ProtoUtils.FromProto.listTaskPushNotificationConfigResult(builder));
             }
-            case DeleteTaskPushNotificationConfigRequest.METHOD -> {
+            case DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 return new DeleteTaskPushNotificationConfigResponse(id);
             }
-            case GetAuthenticatedExtendedCardRequest.METHOD -> {
+            case GET_EXTENDED_AGENT_CARD_METHOD -> {
                 io.a2a.grpc.AgentCard.Builder builder = io.a2a.grpc.AgentCard.newBuilder();
                 parseRequestBody(paramsNode, builder, id);
                 return new GetAuthenticatedExtendedCardResponse(id, ProtoUtils.FromProto.agentCard(builder));
@@ -322,28 +334,28 @@ public class JSONRPCUtils {
     public static A2AResponse<?> parseError(JsonObject error, Object id, String method) throws JsonMappingException {
         A2AError rpcError = processError(error);
         switch (method) {
-            case GetTaskRequest.METHOD -> {
+            case GET_TASK_METHOD -> {
                 return new GetTaskResponse(id, rpcError);
             }
-            case CancelTaskRequest.METHOD -> {
+            case CANCEL_TASK_METHOD -> {
                 return new CancelTaskResponse(id, rpcError);
             }
-            case ListTasksRequest.METHOD -> {
+            case LIST_TASK_METHOD -> {
                 return new ListTasksResponse(id, rpcError);
             }
-            case SetTaskPushNotificationConfigRequest.METHOD -> {
+            case SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 return new SetTaskPushNotificationConfigResponse(id, rpcError);
             }
-            case GetTaskPushNotificationConfigRequest.METHOD -> {
+            case GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 return new GetTaskPushNotificationConfigResponse(id, rpcError);
             }
-            case SendMessageRequest.METHOD -> {
+            case SEND_MESSAGE_METHOD -> {
                 return new SendMessageResponse(id, rpcError);
             }
-            case ListTaskPushNotificationConfigRequest.METHOD -> {
+            case LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 return new ListTaskPushNotificationConfigResponse(id, rpcError);
             }
-            case DeleteTaskPushNotificationConfigRequest.METHOD -> {
+            case DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD -> {
                 return new DeleteTaskPushNotificationConfigResponse(id, rpcError);
             }
             default ->

--- a/spec-grpc/src/main/java/io/a2a/grpc/utils/ProtoUtils.java
+++ b/spec-grpc/src/main/java/io/a2a/grpc/utils/ProtoUtils.java
@@ -23,7 +23,6 @@ import io.a2a.grpc.mapper.TaskPushNotificationConfigMapper;
 import io.a2a.grpc.mapper.TaskQueryParamsMapper;
 import io.a2a.grpc.mapper.TaskStateMapper;
 import io.a2a.grpc.mapper.TaskStatusUpdateEventMapper;
-import io.a2a.jsonrpc.common.wrappers.GetAuthenticatedExtendedCardRequest;
 import io.a2a.jsonrpc.common.wrappers.ListTasksResult;
 import io.a2a.spec.AgentCard;
 import io.a2a.spec.DeleteTaskPushNotificationConfigParams;
@@ -56,7 +55,7 @@ public class ProtoUtils {
             return AgentCardMapper.INSTANCE.toProto(agentCard);
         }
 
-        public static io.a2a.grpc.GetExtendedAgentCardRequest extendedAgentCard(GetAuthenticatedExtendedCardRequest request) {
+        public static io.a2a.grpc.GetExtendedAgentCardRequest extendedAgentCard() {
             return GetExtendedAgentCardRequest.newBuilder().build();
         }
 

--- a/spec-grpc/src/test/java/io/a2a/grpc/utils/JSONRPCUtilsTest.java
+++ b/spec-grpc/src/test/java/io/a2a/grpc/utils/JSONRPCUtilsTest.java
@@ -1,6 +1,8 @@
 package io.a2a.grpc.utils;
 
 import static io.a2a.grpc.utils.JSONRPCUtils.ERROR_MESSAGE;
+import static io.a2a.spec.A2AMethods.GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
+import static io.a2a.spec.A2AMethods.SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -285,7 +287,7 @@ public class JSONRPCUtilsTest {
             """;
 
         SetTaskPushNotificationConfigResponse response =
-            (SetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(responseJson, SetTaskPushNotificationConfigRequest.METHOD);
+            (SetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(responseJson, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
 
         assertNotNull(response);
         assertEquals(1, response.getId());
@@ -311,7 +313,7 @@ public class JSONRPCUtilsTest {
             """;
 
         GetTaskPushNotificationConfigResponse response =
-            (GetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(responseJson, GetTaskPushNotificationConfigRequest.METHOD);
+            (GetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(responseJson, GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
 
         assertNotNull(response);
         assertEquals(2, response.getId());
@@ -334,7 +336,7 @@ public class JSONRPCUtilsTest {
             """;
 
         SetTaskPushNotificationConfigResponse response =
-            (SetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(errorResponse, SetTaskPushNotificationConfigRequest.METHOD);
+            (SetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(errorResponse, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
 
         assertNotNull(response);
         assertEquals(5, response.getId());
@@ -358,7 +360,7 @@ public class JSONRPCUtilsTest {
             """;
 
         SetTaskPushNotificationConfigResponse response =
-            (SetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(errorResponse, SetTaskPushNotificationConfigRequest.METHOD);
+            (SetTaskPushNotificationConfigResponse) JSONRPCUtils.parseResponseBody(errorResponse, SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD);
 
         assertNotNull(response);
         assertEquals(6, response.getId());

--- a/spec/src/main/java/io/a2a/spec/A2AMethods.java
+++ b/spec/src/main/java/io/a2a/spec/A2AMethods.java
@@ -1,0 +1,17 @@
+
+package io.a2a.spec;
+
+public interface A2AMethods {
+    String CANCEL_TASK_METHOD = "CancelTask";
+    String DELETE_TASK_PUSH_NOTIFICATION_CONFIG_METHOD = "DeleteTaskPushNotificationConfig";
+    String GET_EXTENDED_AGENT_CARD_METHOD = "GetExtendedAgentCard";
+    String GET_TASK_METHOD = "GetTask";
+    String GET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD = "GetTaskPushNotificationConfig";
+    String LIST_TASK_METHOD = "ListTasks";
+    String LIST_TASK_PUSH_NOTIFICATION_CONFIG_METHOD = "ListTaskPushNotificationConfig";
+    String SEND_MESSAGE_METHOD = "SendMessage";
+    String SEND_STREAMING_MESSAGE_METHOD = "SendStreamingMessage";
+    String SET_TASK_PUSH_NOTIFICATION_CONFIG_METHOD = "SetTaskPushNotificationConfig";
+    String SUBSCRIBE_TO_TASK_METHOD = "SubscribeToTask";
+
+}

--- a/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
+++ b/tests/server-common/src/test/java/io/a2a/server/apps/common/AbstractA2AServerTest.java
@@ -1,5 +1,6 @@
 package io.a2a.server.apps.common;
 
+import static io.a2a.spec.A2AMethods.SEND_STREAMING_MESSAGE_METHOD;
 import static io.a2a.spec.AgentCard.CURRENT_PROTOCOL_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -1695,7 +1696,7 @@ public abstract class AbstractA2AServerTest {
                 .build();
         String body = "";
         if (request instanceof SendStreamingMessageRequest streamingRequest) {
-            body = JSONRPCUtils.toJsonRPCRequest((String) streamingRequest.getId(), SendStreamingMessageRequest.METHOD, ProtoUtils.ToProto.sendMessageRequest(streamingRequest.getParams()));
+            body = JSONRPCUtils.toJsonRPCRequest((String) streamingRequest.getId(), SEND_STREAMING_MESSAGE_METHOD, ProtoUtils.ToProto.sendMessageRequest(streamingRequest.getParams()));
         }
 
         // Create the request


### PR DESCRIPTION
- Create A2AMethods interface with constants for all A2A protocol methods
- Replace hardcoded method strings across all transport implementations
- Update gRPC, JSONRPC, and REST transports to use centralized constants
- Remove duplicate METHOD constants from individual request wrapper classes
- Update all test files to use new method name constants
- Clean up POM dependencies and update protobuf-maven-plugin to 4.0.3

This refactoring improves maintainability by having a single source of truth for method names and reduces the risk of typos or inconsistencies.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests pass
- [ ] Appropriate READMEs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕